### PR TITLE
Fixing an error due to version 1.16.3 of NumPy

### DIFF
--- a/medgan.py
+++ b/medgan.py
@@ -41,7 +41,7 @@ class Medgan(object):
         self.l2scale = l2scale
 
     def loadData(self, dataPath=''):
-        data = np.load(dataPath)
+        data = np.load(dataPath, allow_pickle=True)
 
         if self.dataType == 'binary':
             data = np.clip(data, 0, 1)
@@ -373,7 +373,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     args = parse_arguments(parser)
 
-    data = np.load(args.data_file)
+    data = np.load(args.data_file, allow_pickle=True)
     inputDim = data.shape[1]
 
     mg = Medgan(dataType=args.data_type,


### PR DESCRIPTION
In NumPy version `1.16.3`, the default value of the argument `allow_pickle` in the [`numpy.load` function](https://www.numpy.org/devdocs/reference/generated/numpy.load.html) is `False` (while it was `True` in the previous NumPy versions).  Thus, I added the argument `allow_pickle=True` each time we call the `numpy.load` function.